### PR TITLE
v1.1.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,19 +10,24 @@ source:
 
 build:
   number: 0
-  noarch: python
-  script: python -m pip install --no-deps --ignore-installed .
+  script: python -m pip install --no-deps --ignore-installed --no-build-isolation .
 
 requirements:
   host:
     - python
     - pip
+    - setuptools
+    - wheel
     - numpy
   run:
     - python
     - numpy
 
 test:
+  requires:
+    - pip
+  commands:
+    - pip check
   imports:
     - colorspacious
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,10 +28,19 @@ test:
 
 about:
   home: https://github.com/njsmith/colorspacious
+  doc_url: https://colorspacious.readthedocs.io/
+  dev_url: https://github.com/njsmith/colorspacious
   license: MIT
   license_family: MIT
   license_file: LICENSE.txt
   summary: A powerful, accurate, and easy-to-use Python library for doing colorspace conversions
+  description: |
+    Colorspacious is a powerful, accurate, and easy-to-use library for performing colorspace conversions.
+
+    In addition to the most common standard colorspaces (sRGB, XYZ, xyY, CIELab, CIELCh), it also 
+    includes: color vision deficiency ("color blindness") simulations using the approach of 
+    Machado et al (2009); a complete implementation of CIECAM02; and the perceptually 
+    uniform CAM02-UCS / CAM02-LCD / CAM02-SCD spaces proposed by Luo et al (2006).
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
# colorspacious v1.1.2

upstream: https://github.com/njsmith/colorspacious/tree/v1.1.2

`yt` -> `cmyt` -> `colorspacious`

## Actions
- Fork from CF
- Update about section
- Remove noarch and add python deps

## Notes
- This is a new package 